### PR TITLE
Rework create_document_list function to read any form type

### DIFF
--- a/SECEdgar/crawler.py
+++ b/SECEdgar/crawler.py
@@ -50,7 +50,7 @@ class SecCrawler():
         data = r.text
 
         # get doc list data
-        doc_list, doc_name_list = self.create_document_list(data)
+        doc_list, doc_name_list = self.create_document_list(data, '10-Q')
 
         try:
             self.save_in_directory(company_code, cik, priorto, doc_list, doc_name_list, '10-Q')
@@ -72,7 +72,7 @@ class SecCrawler():
         data = r.text
 
         # get doc list data
-        doc_list, doc_name_list = self.create_document_list(data)
+        doc_list, doc_name_list = self.create_document_list(data, '10-K')
 
         try:
             self.save_in_directory(company_code, cik, priorto, doc_list, doc_name_list, '10-K')
@@ -95,7 +95,7 @@ class SecCrawler():
         data = r.text
 
         # get doc list data
-        doc_list, doc_name_list = self.create_document_list(data)
+        doc_list, doc_name_list = self.create_document_list(data, '8-K')
 
         try:
             self.save_in_directory(company_code, cik, priorto, doc_list, doc_name_list, '8-K')
@@ -116,7 +116,7 @@ class SecCrawler():
         r = requests.get(base_url)
         data = r.text
 
-        doc_list, doc_name_list = self.create_document_list(data)
+        doc_list, doc_name_list = self.create_document_list(data, '13F')
 
         try:
             self.save_in_directory(company_code, cik, priorto, doc_list,
@@ -126,18 +126,19 @@ class SecCrawler():
 
         print ("Successfully downloaded all the files")
 
-    def create_document_list(self, data):
+    def create_document_list(self, data, form_type):
         # parse fetched data using beatifulsoup
         soup = BeautifulSoup(data)
         # store the link in the list
         link_list = list()
 
         # If the link is .htm convert it to .html
-        for link in soup.find_all('filinghref'):
-            url = link.string
-            if link.string.split(".")[len(link.string.split("."))-1] == "htm":
+        for link in soup.find_all('filing'):
+            url = link.filinghref.string
+            if link.filinghref.string.split(".")[len(link.filinghref.string.split("."))-1] == "htm":
                 url += "l"
-            link_list.append(url)
+            if link.type.string == form_type:
+                link_list.append(url)
         link_list_final = link_list
 
         print ("Number of files to download {0}".format(len(link_list_final)))


### PR DESCRIPTION
Added an argument for the form type to create_document_list(). Then the function reads a link's form type from the HTML and compares it to the argument to ensure it's the right type. This should make it easy to create APIs for any form type, such as Form 4 (even when querying for Form 4 also gives results for Form 424B2).