### PR TITLE
Fixed bug that always downloaded all filing types

### DIFF
--- a/SECEdgar/filings/base.py
+++ b/SECEdgar/filings/base.py
@@ -18,9 +18,7 @@ class Filing(_EDGARBase):
 
     .. versionadded:: 0.1.5
     """
-    _VALID_FILING_TYPES = ["10q", "10-q", "10k",
-                           "10-k", "8k", "8-k",
-                           "13f", "13-f", "4", "sd"]
+    _VALID_FILING_TYPES = ["10-q", "10-k", "8-k", "13-f", "4", "sd"]
 
     def __init__(self, cik, filing_type, **kwargs):
         super(Filing, self).__init__(**kwargs)
@@ -28,7 +26,8 @@ class Filing(_EDGARBase):
         self._filing_type = self._validate_filing_type(filing_type)
         self._cik = cik
         self._params.update({"action": "getcompany", "owner": "exclude",
-                             "output": "xml", "start": 0, "count": 100, "CIK": self.cik})
+                             "output": "xml", "start": 0, "count": 100, "CIK": self.cik,
+                             "type":self._filing_type}})
 
     @property
     def url(self):

--- a/SECEdgar/filings/base.py
+++ b/SECEdgar/filings/base.py
@@ -26,7 +26,7 @@ class Filing(_EDGARBase):
         self._filing_type = self._validate_filing_type(filing_type)
         self._cik = cik
         self._params.update({"action": "getcompany", "owner": "exclude",
-                             "output": "xml", "start": 0, "count": 100, "CIK": self.cik,
+                             "output": "xml", "start": 0, "count": 100, "CIK": self._cik,
                              "type":self._filing_type}})
 
     @property


### PR DESCRIPTION
Fixed bug that downloaded all filing types regardless of which filing type the user specified. Now it downloads only the filing types specified by the user (although not exactly, for example if you specify 10-K it downloads 10-K2A too)

- [X ] closes #62 
- [ X] tests added / passed
- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] added entry to docs/whatsnew latest version