### PR TITLE
Checks for errors

### DIFF
--- a/SECEdgar/filings/base.py
+++ b/SECEdgar/filings/base.py
@@ -161,7 +161,6 @@ class Filing(_EDGARBase):
             raise Exception("No text urls")
         doc_names = [url.split("/")[-1] for url in txt_urls]
         if len(doc_names) == 0:
-            raise Exception("No docs found")
         for (url, doc_name) in list(zip(txt_urls, doc_names)):
             r = requests.get(url)
             data = r.text

--- a/SECEdgar/filings/base.py
+++ b/SECEdgar/filings/base.py
@@ -160,7 +160,6 @@ class Filing(_EDGARBase):
         if len(txt_urls) == 0:
             raise Exception("No text urls")
         doc_names = [url.split("/")[-1] for url in txt_urls]
-        if len(doc_names) == 0:
         for (url, doc_name) in list(zip(txt_urls, doc_names)):
             r = requests.get(url)
             data = r.text

--- a/SECEdgar/filings/base.py
+++ b/SECEdgar/filings/base.py
@@ -156,8 +156,15 @@ class Filing(_EDGARBase):
         """
         directory = self._sanitize_path(directory)
         self._make_dir(directory)
+        
         txt_urls = self._get_urls()
+        if len(txt_urls) == 0:
+            raise Exception("No text urls")
+
         doc_names = [url.split("/")[-1] for url in txt_urls]
+        if len(doc_names) == 0:
+            raise Exception("No docs found")
+
         for (url, doc_name) in list(zip(txt_urls, doc_names)):
             r = requests.get(url)
             data = r.text

--- a/SECEdgar/filings/base.py
+++ b/SECEdgar/filings/base.py
@@ -156,15 +156,12 @@ class Filing(_EDGARBase):
         """
         directory = self._sanitize_path(directory)
         self._make_dir(directory)
-        
         txt_urls = self._get_urls()
         if len(txt_urls) == 0:
             raise Exception("No text urls")
-
         doc_names = [url.split("/")[-1] for url in txt_urls]
         if len(doc_names) == 0:
             raise Exception("No docs found")
-
         for (url, doc_name) in list(zip(txt_urls, doc_names)):
             r = requests.get(url)
             data = r.text


### PR DESCRIPTION
You need to check for errors in the download.
For example, I was behind a Starbuck's connection, and if the user-agent changes to the requests user agent, a page which asks to login in the network is returned, instead of the SEC search results, and so the download silently fails.

Checking for errors allow you instead to spot the error in the download.